### PR TITLE
Fix StatusPartialServiceDisruption value

### DIFF
--- a/statusio.go
+++ b/statusio.go
@@ -61,7 +61,7 @@ var (
 var (
 	StatusOperational              Status = 100
 	StatusDegradedPerformance      Status = 300
-	StatusPartialServiceDisruption Status = 300
+	StatusPartialServiceDisruption Status = 400
 	StatusServiceDisruption        Status = 500
 	StatusSecurityEvent            Status = 600
 )


### PR DESCRIPTION
Fix a bug where StatusPartialServiceDisruption value was accidentally set to 300 instead of 400