### PR TITLE
fix unmarshal of MaintenanceSingleResponse

### DIFF
--- a/maintenance_types.go
+++ b/maintenance_types.go
@@ -102,7 +102,7 @@ type MaintenanceSingleResponse struct {
 		Error   string `json:"error"`
 		Message string `json:"message"`
 	} `json:"status"`
-	Result []MaintenanceResponse `json:"result"`
+	Result MaintenanceResponse `json:"result"`
 }
 
 type MaintenanceMessageResponse struct {


### PR DESCRIPTION
`MaintenanceSingle` results in `json: cannot unmarshal object into Go struct field MaintenanceSingleResponse.result of type []statusio.MaintenanceResponse`. Seems like the corresponding type was broken.