### PR TITLE
Add "silent" flag to Subscriber struct, update "granular" with "omitempty"

### DIFF
--- a/statusio_test.go
+++ b/statusio_test.go
@@ -39,6 +39,7 @@ func Test_StatusioApi_SubscribersAdd(t *testing.T) {
 		StatuspageID: statusPageID,
 		Method:       "email",
 		Address:      "test@example.com",
+		Silent:       "1",
 		Granular:     "",
 	})
 
@@ -55,6 +56,7 @@ func Test_StatusioApi_SubscribersUpdate(t *testing.T) {
 		SubscriberID: id1,
 		Method:       "email",
 		Address:      "test@example.com",
+		Silent:       "1",
 		Granular:     "",
 	})
 

--- a/subscribers_types.go
+++ b/subscribers_types.go
@@ -9,7 +9,8 @@ type Subscriber struct {
 	SubscriberID string `json:"subscriber_id,omitempty"`
 	Method       string `json:"method"`
 	Address      string `json:"address"`
-	Granular     string `json:"granular"`
+	Silent       string `json:"silent,omitempty"`
+	Granular     string `json:"granular,omitempty"`
 }
 
 type SubscriberResponse struct {


### PR DESCRIPTION
The adds the flag allowing email subscribers to be added, without sending them the notification email.

Super useful for some scenarios, for examplt when migrating an internal system with an existing subscriber list to status.io.

The second piece of the change is to make the "granular" field optional, to match the (current) official docs.