### PR TITLE
fix: added missing field in IncidentResponse struct

### DIFF
--- a/incidents_types.go
+++ b/incidents_types.go
@@ -55,8 +55,9 @@ type IncidentResponse struct {
 		Containers []string  `json:"containers"`
 		Components []string  `json:"components"`
 	} `json:"messages"`
-	Name       string `json:"name"`
-	Statuspage string `json:"statuspage"`
+	Name          string `json:"name"`
+	PostMortemUrl string `json:"post_mortem_url"`
+	Statuspage    string `json:"statuspage"`
 }
 
 type IncidentListResponse struct {


### PR DESCRIPTION
When polling directly the incident/list API we're able to retrieve the post_mortem_url, which is part of the IncidentResponse structure.
I would like to be able to leverage that as part of some automation, hence would need this field to be added as part of the expected return structure.

Thank you for your time reviewing this